### PR TITLE
Nicholas Irving (nirving@darkedges.com)

### DIFF
--- a/thymeleaf-extras-tiles2/src/main/java/org/thymeleaf/extras/tiles2/renderer/ThymeleafAttributeRenderer.java
+++ b/thymeleaf-extras-tiles2/src/main/java/org/thymeleaf/extras/tiles2/renderer/ThymeleafAttributeRenderer.java
@@ -72,15 +72,37 @@ public class ThymeleafAttributeRenderer
     private static final String SPRING4_STANDARD_DIALECT_CLASS_NAME =
             "org.thymeleaf.spring4.dialect.SpringStandardDialect";
 
-    
-    
+
+    /** Fixed an issue where the ClassLoader was being hit heavily to check to see if 
+        what Spring Dialect was being used. Now check from one class instead of the Class 
+        Loader
+    **/
+    final static Class<?> spring3StandardDialectClass = getSpring3StandardDialectClassname();
+    final static Class<?> spring4StandardDialectClass = getSpring4StandardDialectClassname();
     
     public ThymeleafAttributeRenderer() {
         super();
     }
 
+	private static Class<?> getSpring3StandardDialectClassname() {
+		Class<?> springStandardDialectClass = null;
+		try {
+			springStandardDialectClass = Class
+					.forName(SPRING3_STANDARD_DIALECT_CLASS_NAME);
+		} catch (ClassNotFoundException e) {
+		}
+		return springStandardDialectClass;
+	}
     
-    
+	private static Class<?> getSpring4StandardDialectClassname() {
+		Class<?> springStandardDialectClass = null;
+		try {
+			springStandardDialectClass = Class
+					.forName(SPRING4_STANDARD_DIALECT_CLASS_NAME);
+		} catch (ClassNotFoundException e) {
+		}
+		return springStandardDialectClass;
+	}
     
     @Override
     public void write(final Object value, final Attribute attribute,
@@ -187,29 +209,20 @@ public class ThymeleafAttributeRenderer
         
     }
 
-    
-    
-    
+    /** Fixed an issue where the ClassLoader was being hit heavily to check to see if 
+        what Spring Dialect was being used. Now check from one class instead of the Class 
+        Loader
+    **/
     private static boolean isStandardDialectPresent(final TemplateEngine templateEngine) {
-        
-        try {
-            final Class<?> springStandardDialectClass = 
-                    Class.forName(SPRING3_STANDARD_DIALECT_CLASS_NAME);
-            if (isDialectPresent(templateEngine, springStandardDialectClass)) {
+    
+        if (spring3StandardDialectClass != null)
+            if (isDialectPresent(templateEngine, spring3StandardDialectClass)) {
                 return true;
-            }
-        } catch (final ClassNotFoundException e) {
-            // nothing to do, just do other checks
         }
 
-        try {
-            final Class<?> springStandardDialectClass =
-                    Class.forName(SPRING4_STANDARD_DIALECT_CLASS_NAME);
-            if (isDialectPresent(templateEngine, springStandardDialectClass)) {
+	if (spring4StandardDialectClass != null)
+	    if (isDialectPresent(templateEngine, spring4StandardDialectClass)) {
                 return true;
-            }
-        } catch (final ClassNotFoundException e) {
-            // nothing to do, just do other checks
         }
 
         return isDialectPresent(templateEngine, StandardDialect.class);
@@ -217,7 +230,8 @@ public class ThymeleafAttributeRenderer
     }
  
 
-    
+    /** Beed to clean this up to improve performance
+    **/
     private static boolean isDialectPresent(final TemplateEngine templateEngine, final Class<?> dialectClass) {
         for (final IDialect dialect : templateEngine.getDialects()) {
             if (dialectClass.isAssignableFrom(dialect.getClass())) {


### PR DESCRIPTION
- Fixed an issue where the ClassLoader was being hit heavily to check to see what Spring Dialect was being used. Now check from one class instead of the ClassLoader. This improves a lock found in WebLogic 10.3.6, even after using a Filtered ClassLoader.

Instead of checking if what classes are on the ClassPath everytime with Class.forName, this change caches the class lookup for each Spring Dialect. I have seen similair changes in the code base to cache configuration items, but not the class. This improveda lock found in WebLogic when executing over 20+ requests per second.
